### PR TITLE
Dependabot setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 999
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 999
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
I am unsure on the amount of time dedicated to this package so I figured to ignore major version updates to not induce breaking changes (assuming the deps' maintainers follow proper semver).

There is a step 2 that can't be done via PR, but in the project `Settings` > `Code security and analysis`, make sure `Dependency graph` and `Dependabot version updates` are enabled at a minimum for dependabot to work (although I strongly recommend everything on that page to be enabled)